### PR TITLE
network client 비동기 리팩토링

### DIFF
--- a/dummy/src/test/kotlin/MainIntegrationTest.kt
+++ b/dummy/src/test/kotlin/MainIntegrationTest.kt
@@ -48,38 +48,11 @@ class MainIntegrationTest {
         )
         val serverUrl = mockWebServer.url("/collect").toString()
 
-        val result = dataCollector.collect(serverUrl, dummyUser)
-
-        assertTrue(result.isSuccess, "서버로의 데이터 전송이 실패")
+        dataCollector.collect(serverUrl, dummyUser)
 
         val request = mockWebServer.takeRequest()
         assertEquals("/collect", request.path, "요청 경로가 올바르지 않습니다.")
         assertEquals("POST", request.method, "HTTP 메서드가 올바르지 않습니다.")
         assertTrue(request.body.readUtf8().contains("Test User"), "전송된 데이터가 올바르지 않습니다.")
-    }
-
-    @Test
-    fun `통합 테스트 - 서버 오류 시 실패 처리`() {
-        val mockResponse = MockResponse()
-            .setResponseCode(500)
-            .setBody("{ \"error\": \"Internal Server Error\" }")
-        mockWebServer.enqueue(mockResponse)
-
-        val dummyUser = User(
-            name = "Test User",
-            age = 25,
-            level = 5,
-            score = 1000,
-            achievements = listOf("Achievement1", "Achievement2"),
-            active = true
-        )
-        val serverUrl = mockWebServer.url("/collect").toString()
-        val result = dataCollector.collect(serverUrl, dummyUser)
-
-        // 검증
-        assertTrue(result.isFailure, "서버 오류가 제대로 처리되지 않았습니다.")
-        val exception = result.exceptionOrNull()
-        assertNotNull(exception)
-        assertEquals("Error: 500 - Server Error", exception!!.message)
     }
 }

--- a/jvm-sdk/build.gradle.kts
+++ b/jvm-sdk/build.gradle.kts
@@ -14,4 +14,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+
+    // coroutine
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 }

--- a/jvm-sdk/src/main/kotlin/com/gamedatahub/network/JvmNetworkClient.kt
+++ b/jvm-sdk/src/main/kotlin/com/gamedatahub/network/JvmNetworkClient.kt
@@ -1,32 +1,62 @@
 package com.gamedatahub.network
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
-
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.*
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class JvmNetworkClient(
     private val client: OkHttpClient = OkHttpClient()
 ) : NetworkClient {
+    private val scope = CoroutineScope(Dispatchers.IO)
 
-    override fun postData(url: String, data: String): Result<String> {
-        return try {
-            val requestBody = RequestBody.create("application/json".toMediaType(), data) // JSON 데이터 요청
-            val request = Request.Builder()
-                .url(url)
-                .post(requestBody)
-                .build()
-
-            client.newCall(request).execute().use { response ->
-                if (response.isSuccessful) {
-                    Result.success(response.body?.string() ?: "Success")
-                } else {
-                    Result.failure(Exception("Error: ${response.code} - ${response.message}"))
-                }
+    override fun postDataAsync(url: String, data: String) {
+        scope.launch {
+            try {
+                val response = client.makePostRequest(url, data)
+                TODO("성공 핸들링")
+            } catch (e: Exception) {
+                TODO("실패 핸들링")
             }
-        } catch (e: Exception) {
-            Result.failure(e) // 예외 처리
+        }
+    }
+}
+
+private suspend fun OkHttpClient.makePostRequest(url: String, data: String): String {
+    val requestBody = data.toRequestBody("application/json".toMediaType())
+    val request = Request.Builder()
+        .url(url)
+        .post(requestBody)
+        .build()
+
+    return suspendCancellableCoroutine { continuation ->
+        val call = this.newCall(request)
+
+        call.enqueue(object : Callback {
+            override fun onResponse(call: Call, response: Response) {
+                if (response.isSuccessful) {
+                    continuation.resume(response.body?.string() ?: "")
+                } else {
+                    continuation.resumeWithException(Exception("Error: ${response.code} - ${response.message}"))
+                }
+                response.close()
+            }
+
+            override fun onFailure(call: Call, e: IOException) {
+                continuation.resumeWithException(e)
+            }
+        })
+
+        continuation.invokeOnCancellation {
+            call.cancel()
         }
     }
 }

--- a/shared-sdk/src/main/kotlin/com/gamedatahub/datacollection/DataCollector.kt
+++ b/shared-sdk/src/main/kotlin/com/gamedatahub/datacollection/DataCollector.kt
@@ -10,9 +10,9 @@ class DataCollector<T>(
     private val jsonSerializer: JsonSerializer<T>
 ) {
 
-    fun collect(serverUrl: String, data: T): Result<String> {
+    fun collect(serverUrl: String, data: T) {
         val jsonData = serializeToJson(data)
-        return networkClient.postData(serverUrl, jsonData)
+        networkClient.postDataAsync(serverUrl, jsonData)
     }
 
     private fun serializeToJson(data: T): String {

--- a/shared-sdk/src/main/kotlin/com/gamedatahub/network/NetworkClient.kt
+++ b/shared-sdk/src/main/kotlin/com/gamedatahub/network/NetworkClient.kt
@@ -2,5 +2,5 @@ package com.gamedatahub.network
 
 interface NetworkClient {
 
-    fun postData(url: String, data: String): Result<String>
+    fun postDataAsync(url: String, data: String)
 }


### PR DESCRIPTION
### 주요 구현 내용
`JvmNetworkClient 클래스`
- `postDataAsync` 메서드가 Kotlin의 코루틴과 `suspend` 기능을 활용한 구조로 변경되었습니다.
- **OkHttpClient**와 Kotlin의 **suspendCancellableCoroutine**을 활용해 기존 동기 동작을 비동기 방식으로 변경.

**suspendCancellableCoroutine** 사용 이유
- 콜백이 완료될 때까지 코루틴이 일시 중단 상태로 대기하도록 구현하기 위해
- 콜백의 결과를 호출부로 반환하여 코루틴 내에서 처리할 수 있도록 하기 위해
- 코루틴이 취소될 경우 네트워크 요청도 함께 취소되도록 보장하기 위해

#### 추후 구현 사항
- 네트워크 응답 성공/실패 핸들링