### PR TITLE
재시도 로직 구현 및 테스트 추가

### DIFF
--- a/dummy/src/test/kotlin/MainIntegrationTest.kt
+++ b/dummy/src/test/kotlin/MainIntegrationTest.kt
@@ -1,6 +1,7 @@
 import com.gamedatahub.network.JvmNetworkClient
 import com.gamedatahub.datacollection.DataCollector
 import com.gamedatahub.serialization.JsonSerializer
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import serialization.JacksonSerializer
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 class MainIntegrationTest {
 
@@ -22,7 +24,12 @@ class MainIntegrationTest {
         mockWebServer = MockWebServer()
         mockWebServer.start()
 
-        networkClient = JvmNetworkClient.Builder().build()
+        networkClient = JvmNetworkClient.Builder()
+            .enableRetry(true)
+            .maxRetries(3)
+            .retryDelayMillis(10)
+            .backoffFactor(2.0)
+            .build()
         jsonSerializer = JacksonSerializer(clazz = User::class.java)
         dataCollector = DataCollector(networkClient, jsonSerializer)
     }
@@ -84,5 +91,48 @@ class MainIntegrationTest {
         assertEquals(expectedDelayMillis, config.retryDelayMillis, "재시도 딜레이 값이 올바르게 설정되지 않았습니다.")
 
         configFile.delete()
+    }
+
+    @Test
+    fun `서버 실패 시 정해진 횟수만큼 재시도 후 실패한다`() {
+        repeat(networkClient.config.maxRetries) {
+            mockWebServer.enqueue(MockResponse().setResponseCode(500))
+        }
+
+        val serverUrl = mockWebServer.url("/test").toString()
+        networkClient.postDataAsync(serverUrl, "{ \"key\": \"value\" }")
+
+        Thread.sleep(200)
+
+        assertEquals(4, mockWebServer.requestCount, "요청 횟수가 재시도 설정에 맞지 않습니다.")
+    }
+
+    @Test
+    fun `재시도 중 서버가 성공하면 요청이 종료된다`() {
+        repeat(networkClient.config.maxRetries - 1) {
+            mockWebServer.enqueue(MockResponse().setResponseCode(500))
+        }
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+
+        val serverUrl = mockWebServer.url("/test").toString()
+        networkClient.postDataAsync(serverUrl, "{ \"key\": \"value\" }")
+
+        Thread.sleep(200)
+
+        assertEquals(3, mockWebServer.requestCount, "재시도 중간에 요청이 성공하지 않았습니다.")
+    }
+
+    @Test
+    fun `재시도 설정이 비활성화된 경우 한 번만 요청한다`() {
+        val clientWithoutRetry = JvmNetworkClient.Builder()
+            .enableRetry(false)
+            .build()
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val serverUrl = mockWebServer.url("/test").toString()
+        clientWithoutRetry.postDataAsync(serverUrl, "{ \"key\": \"value\" }")
+
+        Thread.sleep(200)
+        assertEquals(1, mockWebServer.requestCount, "비활성화된 재시도에서 요청 횟수가 잘못되었습니다.")
     }
 }

--- a/jvm-sdk/build.gradle.kts
+++ b/jvm-sdk/build.gradle.kts
@@ -15,6 +15,4 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 
-    // coroutine
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 }

--- a/jvm-sdk/src/main/kotlin/com/gamedatahub/network/JvmNetworkClient.kt
+++ b/jvm-sdk/src/main/kotlin/com/gamedatahub/network/JvmNetworkClient.kt
@@ -11,10 +11,10 @@ import java.io.File
 import java.io.IOException
 
 data class NetworkClientConfig(
-    var isRetryEnabled: Boolean = true,
-    var maxRetries: Int = 2,
-    var retryDelayMillis: Long = 1000,
-    var backoffFactor: Double = 2.0
+    val isRetryEnabled: Boolean = true,
+    val maxRetries: Int = 2,
+    val retryDelayMillis: Long = 1000,
+    val backoffFactor: Double = 2.0
 )
 
 class JvmNetworkClient private constructor(


### PR DESCRIPTION
#### 주요 변경 사항
1. **재시도 로직 구현**
    - `JvmNetworkClient` 내부 `makePostRequestAsync` 메서드에 재시도 기능 추가.
    - 실패 시 설정된 최대 재시도 횟수(`maxRetries`)만큼 요청을 반복.
    - 재시도 간의 딜레이는 `retryDelayMillis` 값과 지수 백오프(`backoffFactor`)를 통해 증가하도록 설정.

2. **테스트 코드 작성**
    - `MainIntegrationTest.kt`에 재시도 로직 검증 테스트 추가.
       - 요청 실패 시 정해진 횟수 만큼 시도하는지 검증